### PR TITLE
Add propValue analysis

### DIFF
--- a/__tests__/__snapshots__/api.test.ts.snap
+++ b/__tests__/__snapshots__/api.test.ts.snap
@@ -259,9 +259,9 @@ exports[`analyze multiple prop types in prop-usage directory 1`] = `
 Object {
   "componentTotal": 1,
   "componentUsage": Object {
-    "div": 7,
+    "div": 8,
   },
-  "componentUsageTotal": 7,
+  "componentUsageTotal": 8,
   "directory": Any<String>,
   "elapsedTime": Any<Number>,
   "errors": Object {},
@@ -329,44 +329,58 @@ Object {
         },
         Object {
           "endLoc": Position {
-            "column": 20,
+            "column": 19,
             "line": 6,
           },
           "filename": "multiplePropTypes.js",
-          "prettyCode": "   6 |   <div value={false} /> {/* boolean */}",
+          "prettyCode": "   6 |   <div value={null} /> {/* null */}",
+          "propCode": "value={null}",
+          "propValue": null,
+          "startLoc": Position {
+            "column": 7,
+            "line": 6,
+          },
+        },
+        Object {
+          "endLoc": Position {
+            "column": 20,
+            "line": 7,
+          },
+          "filename": "multiplePropTypes.js",
+          "prettyCode": "   7 |   <div value={false} /> {/* boolean */}",
           "propCode": "value={false}",
           "propValue": false,
           "startLoc": Position {
             "column": 7,
-            "line": 6,
+            "line": 7,
           },
         },
         Object {
           "endLoc": Position {
             "column": 26,
-            "line": 7,
+            "line": 8,
           },
           "filename": "multiplePropTypes.js",
-          "prettyCode": "   7 |   <div value={\`It works!\`} /> {/* template literal */}",
+          "prettyCode": "   8 |   <div value={\`It works!\`} /> {/* template literal */}",
           "propCode": "value={\`It works!\`}",
           "propValue": Symbol(formatPropValue.EXPRESSION),
           "startLoc": Position {
             "column": 7,
-            "line": 7,
+            "line": 8,
           },
         },
         Object {
           "endLoc": Position {
             "column": 28,
-            "line": 8,
+            "line": 9,
           },
           "filename": "multiplePropTypes.js",
-          "prettyCode": "   8 |   <div value={\`\${10}-hello\`} /> {/* dynamic template literal */}",
+          "prettyCode": "   9 |   <div value={\`\${10}-hello\`} /> {/* dynamic template literal */}",
           "propCode": "value={\`\${10}-hello\`}",
           "propValue": Symbol(formatPropValue.EXPRESSION),
           "startLoc": Position {
             "column": 7,
-            "line": 8,
+            "line": 9,
           },
         },
       ],
@@ -374,7 +388,7 @@ Object {
   },
   "propUsage": Object {
     "div": Object {
-      "value": 7,
+      "value": 8,
     },
   },
   "suggestedPlugins": Array [],
@@ -385,9 +399,9 @@ exports[`analyze prop-usage directory 1`] = `
 Object {
   "componentTotal": 1,
   "componentUsage": Object {
-    "div": 15,
+    "div": 16,
   },
-  "componentUsageTotal": 15,
+  "componentUsageTotal": 16,
   "directory": Any<String>,
   "elapsedTime": Any<Number>,
   "errors": Object {},

--- a/__tests__/__snapshots__/api.test.ts.snap
+++ b/__tests__/__snapshots__/api.test.ts.snap
@@ -24,6 +24,7 @@ Object {
           "filename": "main.js",
           "prettyCode": "   1 | <div a b c />;",
           "propCode": "a",
+          "propValue": "true",
           "startLoc": Position {
             "column": 5,
             "line": 1,
@@ -39,6 +40,7 @@ Object {
           "filename": "main.js",
           "prettyCode": "   1 | <div a b c />;",
           "propCode": "b",
+          "propValue": "true",
           "startLoc": Position {
             "column": 7,
             "line": 1,
@@ -54,6 +56,7 @@ Object {
           "filename": "main.js",
           "prettyCode": "   1 | <div a b c />;",
           "propCode": "c",
+          "propValue": "true",
           "startLoc": Position {
             "column": 9,
             "line": 1,
@@ -192,6 +195,7 @@ Object {
           "filename": "main.js",
           "prettyCode": "   6 |       <div className=\\"abc\\" style={{ fontSize: 20 }} id=\\"nice\\" />",
           "propCode": "id=\\"nice\\"",
+          "propValue": "nice",
           "startLoc": Position {
             "column": 52,
             "line": 6,
@@ -205,6 +209,7 @@ Object {
           "filename": "main.js",
           "prettyCode": "   7 |       <div className=\\"efg\\" style={{ fontSize: 22 }} id=\\"cool\\" />",
           "propCode": "id=\\"cool\\"",
+          "propValue": "cool",
           "startLoc": Position {
             "column": 52,
             "line": 7,
@@ -218,6 +223,7 @@ Object {
           "filename": "main.js",
           "prettyCode": "   9 |       <div className=\\"klm\\" style={{ fontSize: 26 }} id=\\"potato\\" />",
           "propCode": "id=\\"potato\\"",
+          "propValue": "potato",
           "startLoc": Position {
             "column": 52,
             "line": 9,
@@ -231,6 +237,7 @@ Object {
           "filename": "main.js",
           "prettyCode": "  10 |       <div className=\\"nop\\" style={{ fontSize: 28 }} id={\\"salad\\"} />",
           "propCode": "id={\\"salad\\"}",
+          "propValue": "salad",
           "startLoc": Position {
             "column": 52,
             "line": 10,
@@ -248,18 +255,131 @@ Object {
 }
 `;
 
+exports[`analyze multiple prop types in prop-usage directory 1`] = `
+Object {
+  "componentTotal": 1,
+  "componentUsage": Object {
+    "div": 6,
+  },
+  "componentUsageTotal": 6,
+  "directory": Any<String>,
+  "elapsedTime": Any<Number>,
+  "errors": Object {},
+  "filenames": Array [
+    "multiplePropTypes.js",
+  ],
+  "lineUsage": Object {
+    "div": Object {
+      "value": Array [
+        Object {
+          "endLoc": Position {
+            "column": 41,
+            "line": 1,
+          },
+          "filename": "multiplePropTypes.js",
+          "prettyCode": "   1 | <div value=\\"asdfjklasdfjklasdfjklasdfjkl\\" />; // string",
+          "propCode": "value=\\"asdfjklasdfjklasdfjklasdfjkl\\"",
+          "propValue": "asdfjklasdfjklasdfjklasdfjkl",
+          "startLoc": Position {
+            "column": 5,
+            "line": 1,
+          },
+        },
+        Object {
+          "endLoc": Position {
+            "column": 15,
+            "line": 2,
+          },
+          "filename": "multiplePropTypes.js",
+          "prettyCode": "   2 | <div value={10} />; // number",
+          "propCode": "value={10}",
+          "propValue": "10",
+          "startLoc": Position {
+            "column": 5,
+            "line": 2,
+          },
+        },
+        Object {
+          "endLoc": Position {
+            "column": 35,
+            "line": 3,
+          },
+          "filename": "multiplePropTypes.js",
+          "prettyCode": "   3 | <div value={{propKey: 'propValue'}} />; // object",
+          "propCode": "value={{propKey: 'propValue'}}",
+          "propValue": Symbol(formatPropValue.EXPRESSION),
+          "startLoc": Position {
+            "column": 5,
+            "line": 3,
+          },
+        },
+        Object {
+          "endLoc": Position {
+            "column": 18,
+            "line": 4,
+          },
+          "filename": "multiplePropTypes.js",
+          "prettyCode": "   4 | <div value={false} />; // boolean",
+          "propCode": "value={false}",
+          "propValue": "false",
+          "startLoc": Position {
+            "column": 5,
+            "line": 4,
+          },
+        },
+        Object {
+          "endLoc": Position {
+            "column": 24,
+            "line": 5,
+          },
+          "filename": "multiplePropTypes.js",
+          "prettyCode": "   5 | <div value={\`It works!\`} />; // template literal",
+          "propCode": "value={\`It works!\`}",
+          "propValue": Symbol(formatPropValue.EXPRESSION),
+          "startLoc": Position {
+            "column": 5,
+            "line": 5,
+          },
+        },
+        Object {
+          "endLoc": Position {
+            "column": 26,
+            "line": 6,
+          },
+          "filename": "multiplePropTypes.js",
+          "prettyCode": "   6 | <div value={\`\${10}-hello\`} />; // dynamic template literal",
+          "propCode": "value={\`\${10}-hello\`}",
+          "propValue": Symbol(formatPropValue.EXPRESSION),
+          "startLoc": Position {
+            "column": 5,
+            "line": 6,
+          },
+        },
+      ],
+    },
+  },
+  "propUsage": Object {
+    "div": Object {
+      "value": 6,
+    },
+  },
+  "suggestedPlugins": Array [],
+}
+`;
+
 exports[`analyze prop-usage directory 1`] = `
 Object {
   "componentTotal": 1,
   "componentUsage": Object {
-    "div": 8,
+    "div": 14,
   },
-  "componentUsageTotal": 8,
+  "componentUsageTotal": 14,
   "directory": Any<String>,
   "elapsedTime": Any<Number>,
   "errors": Object {},
   "filenames": Array [
     "main.js",
+    "multiplePropTypes.js",
   ],
   "lineUsage": Object {
     "div": Object {
@@ -272,6 +392,7 @@ Object {
           "filename": "main.js",
           "prettyCode": "   1 | <div a />;",
           "propCode": "a",
+          "propValue": "true",
           "startLoc": Position {
             "column": 5,
             "line": 1,
@@ -285,6 +406,7 @@ Object {
           "filename": "main.js",
           "prettyCode": "   3 | <div a b />;",
           "propCode": "a",
+          "propValue": "true",
           "startLoc": Position {
             "column": 5,
             "line": 3,
@@ -298,6 +420,7 @@ Object {
           "filename": "main.js",
           "prettyCode": "   4 | <div a b c />;",
           "propCode": "a",
+          "propValue": "true",
           "startLoc": Position {
             "column": 5,
             "line": 4,
@@ -311,6 +434,7 @@ Object {
           "filename": "main.js",
           "prettyCode": "  12 |   a",
           "propCode": "a",
+          "propValue": "true",
           "startLoc": Position {
             "column": 2,
             "line": 12,
@@ -352,6 +476,7 @@ Object {
           "filename": "main.tsx",
           "prettyCode": "   1 | <div typescriptIsCool />;",
           "propCode": "typescriptIsCool",
+          "propValue": "true",
           "startLoc": Position {
             "column": 5,
             "line": 1,

--- a/__tests__/__snapshots__/api.test.ts.snap
+++ b/__tests__/__snapshots__/api.test.ts.snap
@@ -24,7 +24,7 @@ Object {
           "filename": "main.js",
           "prettyCode": "   1 | <div a b c />;",
           "propCode": "a",
-          "propValue": "true",
+          "propValue": true,
           "startLoc": Position {
             "column": 5,
             "line": 1,
@@ -40,7 +40,7 @@ Object {
           "filename": "main.js",
           "prettyCode": "   1 | <div a b c />;",
           "propCode": "b",
-          "propValue": "true",
+          "propValue": true,
           "startLoc": Position {
             "column": 7,
             "line": 1,
@@ -56,7 +56,7 @@ Object {
           "filename": "main.js",
           "prettyCode": "   1 | <div a b c />;",
           "propCode": "c",
-          "propValue": "true",
+          "propValue": true,
           "startLoc": Position {
             "column": 9,
             "line": 1,
@@ -293,7 +293,7 @@ Object {
           "filename": "multiplePropTypes.js",
           "prettyCode": "   3 |   <div value={10} /> {/* number */}",
           "propCode": "value={10}",
-          "propValue": "10",
+          "propValue": 10,
           "startLoc": Position {
             "column": 7,
             "line": 3,
@@ -321,7 +321,7 @@ Object {
           "filename": "multiplePropTypes.js",
           "prettyCode": "   5 |   <div value /> {/* boolean */}",
           "propCode": "value",
-          "propValue": "true",
+          "propValue": true,
           "startLoc": Position {
             "column": 7,
             "line": 5,
@@ -335,7 +335,7 @@ Object {
           "filename": "multiplePropTypes.js",
           "prettyCode": "   6 |   <div value={false} /> {/* boolean */}",
           "propCode": "value={false}",
-          "propValue": "false",
+          "propValue": false,
           "startLoc": Position {
             "column": 7,
             "line": 6,
@@ -406,7 +406,7 @@ Object {
           "filename": "main.js",
           "prettyCode": "   1 | <div a />;",
           "propCode": "a",
-          "propValue": "true",
+          "propValue": true,
           "startLoc": Position {
             "column": 5,
             "line": 1,
@@ -420,7 +420,7 @@ Object {
           "filename": "main.js",
           "prettyCode": "   3 | <div a b />;",
           "propCode": "a",
-          "propValue": "true",
+          "propValue": true,
           "startLoc": Position {
             "column": 5,
             "line": 3,
@@ -434,7 +434,7 @@ Object {
           "filename": "main.js",
           "prettyCode": "   4 | <div a b c />;",
           "propCode": "a",
-          "propValue": "true",
+          "propValue": true,
           "startLoc": Position {
             "column": 5,
             "line": 4,
@@ -448,7 +448,7 @@ Object {
           "filename": "main.js",
           "prettyCode": "  12 |   a",
           "propCode": "a",
-          "propValue": "true",
+          "propValue": true,
           "startLoc": Position {
             "column": 2,
             "line": 12,
@@ -490,7 +490,7 @@ Object {
           "filename": "main.tsx",
           "prettyCode": "   1 | <div typescriptIsCool />;",
           "propCode": "typescriptIsCool",
-          "propValue": "true",
+          "propValue": true,
           "startLoc": Position {
             "column": 5,
             "line": 1,

--- a/__tests__/__snapshots__/api.test.ts.snap
+++ b/__tests__/__snapshots__/api.test.ts.snap
@@ -259,9 +259,9 @@ exports[`analyze multiple prop types in prop-usage directory 1`] = `
 Object {
   "componentTotal": 1,
   "componentUsage": Object {
-    "div": 6,
+    "div": 7,
   },
-  "componentUsageTotal": 6,
+  "componentUsageTotal": 7,
   "directory": Any<String>,
   "elapsedTime": Any<Number>,
   "errors": Object {},
@@ -273,86 +273,100 @@ Object {
       "value": Array [
         Object {
           "endLoc": Position {
-            "column": 41,
-            "line": 1,
+            "column": 43,
+            "line": 2,
           },
           "filename": "multiplePropTypes.js",
-          "prettyCode": "   1 | <div value=\\"asdfjklasdfjklasdfjklasdfjkl\\" />; // string",
+          "prettyCode": "   2 |   <div value=\\"asdfjklasdfjklasdfjklasdfjkl\\" /> {/* string */}",
           "propCode": "value=\\"asdfjklasdfjklasdfjklasdfjkl\\"",
           "propValue": "asdfjklasdfjklasdfjklasdfjkl",
           "startLoc": Position {
-            "column": 5,
-            "line": 1,
+            "column": 7,
+            "line": 2,
           },
         },
         Object {
           "endLoc": Position {
-            "column": 15,
-            "line": 2,
+            "column": 17,
+            "line": 3,
           },
           "filename": "multiplePropTypes.js",
-          "prettyCode": "   2 | <div value={10} />; // number",
+          "prettyCode": "   3 |   <div value={10} /> {/* number */}",
           "propCode": "value={10}",
           "propValue": "10",
           "startLoc": Position {
-            "column": 5,
-            "line": 2,
+            "column": 7,
+            "line": 3,
           },
         },
         Object {
           "endLoc": Position {
-            "column": 35,
-            "line": 3,
+            "column": 37,
+            "line": 4,
           },
           "filename": "multiplePropTypes.js",
-          "prettyCode": "   3 | <div value={{propKey: 'propValue'}} />; // object",
+          "prettyCode": "   4 |   <div value={{propKey: 'propValue'}} /> {/* object */}",
           "propCode": "value={{propKey: 'propValue'}}",
           "propValue": Symbol(formatPropValue.EXPRESSION),
           "startLoc": Position {
-            "column": 5,
-            "line": 3,
+            "column": 7,
+            "line": 4,
           },
         },
         Object {
           "endLoc": Position {
-            "column": 18,
-            "line": 4,
+            "column": 12,
+            "line": 5,
           },
           "filename": "multiplePropTypes.js",
-          "prettyCode": "   4 | <div value={false} />; // boolean",
+          "prettyCode": "   5 |   <div value /> {/* boolean */}",
+          "propCode": "value",
+          "propValue": "true",
+          "startLoc": Position {
+            "column": 7,
+            "line": 5,
+          },
+        },
+        Object {
+          "endLoc": Position {
+            "column": 20,
+            "line": 6,
+          },
+          "filename": "multiplePropTypes.js",
+          "prettyCode": "   6 |   <div value={false} /> {/* boolean */}",
           "propCode": "value={false}",
           "propValue": "false",
           "startLoc": Position {
-            "column": 5,
-            "line": 4,
-          },
-        },
-        Object {
-          "endLoc": Position {
-            "column": 24,
-            "line": 5,
-          },
-          "filename": "multiplePropTypes.js",
-          "prettyCode": "   5 | <div value={\`It works!\`} />; // template literal",
-          "propCode": "value={\`It works!\`}",
-          "propValue": Symbol(formatPropValue.EXPRESSION),
-          "startLoc": Position {
-            "column": 5,
-            "line": 5,
+            "column": 7,
+            "line": 6,
           },
         },
         Object {
           "endLoc": Position {
             "column": 26,
-            "line": 6,
+            "line": 7,
           },
           "filename": "multiplePropTypes.js",
-          "prettyCode": "   6 | <div value={\`\${10}-hello\`} />; // dynamic template literal",
+          "prettyCode": "   7 |   <div value={\`It works!\`} /> {/* template literal */}",
+          "propCode": "value={\`It works!\`}",
+          "propValue": Symbol(formatPropValue.EXPRESSION),
+          "startLoc": Position {
+            "column": 7,
+            "line": 7,
+          },
+        },
+        Object {
+          "endLoc": Position {
+            "column": 28,
+            "line": 8,
+          },
+          "filename": "multiplePropTypes.js",
+          "prettyCode": "   8 |   <div value={\`\${10}-hello\`} /> {/* dynamic template literal */}",
           "propCode": "value={\`\${10}-hello\`}",
           "propValue": Symbol(formatPropValue.EXPRESSION),
           "startLoc": Position {
-            "column": 5,
-            "line": 6,
+            "column": 7,
+            "line": 8,
           },
         },
       ],
@@ -360,7 +374,7 @@ Object {
   },
   "propUsage": Object {
     "div": Object {
-      "value": 6,
+      "value": 7,
     },
   },
   "suggestedPlugins": Array [],
@@ -371,9 +385,9 @@ exports[`analyze prop-usage directory 1`] = `
 Object {
   "componentTotal": 1,
   "componentUsage": Object {
-    "div": 14,
+    "div": 15,
   },
-  "componentUsageTotal": 14,
+  "componentUsageTotal": 15,
   "directory": Any<String>,
   "elapsedTime": Any<Number>,
   "errors": Object {},

--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -94,3 +94,18 @@ test("analyze prop-usage directory", async () => {
     elapsedTime: expect.any(Number),
   });
 });
+
+test("analyze multiple prop types in prop-usage directory", async () => {
+  const directory = path.resolve(__dirname, "../fixtures/prop-usage");
+  const analysis = await analyze({
+    directory,
+    files: ['multiplePropTypes.js'],
+    components: ["div"],
+    prop: "value",
+    relativePaths: true,
+  });
+  expect(analysis).toMatchSnapshot({
+    directory: expect.any(String),
+    elapsedTime: expect.any(Number),
+  });
+});

--- a/fixtures/prop-usage/multiplePropTypes.js
+++ b/fixtures/prop-usage/multiplePropTypes.js
@@ -1,0 +1,6 @@
+<div value="asdfjklasdfjklasdfjklasdfjkl" />; // string
+<div value={10} />; // number
+<div value={{propKey: 'propValue'}} />; // object
+<div value={false} />; // boolean
+<div value={`It works!`} />; // template literal
+<div value={`${10}-hello`} />; // dynamic template literal

--- a/fixtures/prop-usage/multiplePropTypes.js
+++ b/fixtures/prop-usage/multiplePropTypes.js
@@ -3,6 +3,7 @@
   <div value={10} /> {/* number */}
   <div value={{propKey: 'propValue'}} /> {/* object */}
   <div value /> {/* boolean */}
+  <div value={null} /> {/* null */}
   <div value={false} /> {/* boolean */}
   <div value={`It works!`} /> {/* template literal */}
   <div value={`${10}-hello`} /> {/* dynamic template literal */}

--- a/fixtures/prop-usage/multiplePropTypes.js
+++ b/fixtures/prop-usage/multiplePropTypes.js
@@ -1,6 +1,9 @@
-<div value="asdfjklasdfjklasdfjklasdfjkl" />; // string
-<div value={10} />; // number
-<div value={{propKey: 'propValue'}} />; // object
-<div value={false} />; // boolean
-<div value={`It works!`} />; // template literal
-<div value={`${10}-hello`} />; // dynamic template literal
+<>
+  <div value="asdfjklasdfjklasdfjklasdfjkl" /> {/* string */}
+  <div value={10} /> {/* number */}
+  <div value={{propKey: 'propValue'}} /> {/* object */}
+  <div value /> {/* boolean */}
+  <div value={false} /> {/* boolean */}
+  <div value={`It works!`} /> {/* template literal */}
+  <div value={`${10}-hello`} /> {/* dynamic template literal */}
+</>

--- a/src/api.ts
+++ b/src/api.ts
@@ -45,6 +45,7 @@ export interface ErrorInfo {
 /** Information about a line where a prop was used */
 export interface LineInfo {
   propCode: string;
+  propValue: string | symbol;
   prettyCode: string;
   startLoc: SourceLocation;
   endLoc: SourceLocation;
@@ -143,6 +144,7 @@ export async function analyze({
               }
               reporter.addProp(componentName, searchProp, {
                 propCode: code.slice(node.start || 0, node.end || -1),
+                propValue: formatPropValue(null),
                 startLoc: node.loc.start,
                 endLoc: node.loc.end,
                 prettyCode: formatPrettyCode(
@@ -182,6 +184,7 @@ export async function analyze({
               ) {
                 reporter.addProp(componentName, prop.propName, {
                   propCode: prop.propCode,
+                  propValue: prop.propValue,
                   startLoc: prop.startLoc,
                   endLoc: prop.endLoc,
                   prettyCode: formatPrettyCode(

--- a/src/api.ts
+++ b/src/api.ts
@@ -47,8 +47,9 @@ export interface ErrorInfo {
  *
  * symbol is when prop value can't be represented (expression is used as prop value)
  * undefined is used when when prop value can't be calculated
+ * null when prop is with {null} value
  * */
-export type PropValue = symbol | number | string | boolean | undefined;
+export type PropValue = symbol | number | string | boolean | null | undefined;
 
 /** Information about a line where a prop was used */
 export interface LineInfo {
@@ -255,15 +256,14 @@ function formatPropValue(value: Node | null): PropValue {
   if (value === null) {
     return true;
   }
-  if (!value) {
-    return EXPRESSION;
-  }
   switch (value.type) {
     // TODO: Should we interpret anything else here?
     case "StringLiteral":
     case "NumericLiteral":
     case "BooleanLiteral":
       return value.value;
+    case "NullLiteral":
+      return null;
     case "JSXExpressionContainer":
       return formatPropValue(value.expression);
     default:

--- a/src/api.ts
+++ b/src/api.ts
@@ -45,7 +45,7 @@ export interface ErrorInfo {
 /** Information about a line where a prop was used */
 export interface LineInfo {
   propCode: string;
-  propValue: string | symbol;
+  propValue: string | symbol | undefined;
   prettyCode: string;
   startLoc: SourceLocation;
   endLoc: SourceLocation;
@@ -144,7 +144,7 @@ export async function analyze({
               }
               reporter.addProp(componentName, searchProp, {
                 propCode: code.slice(node.start || 0, node.end || -1),
-                propValue: formatPropValue(null),
+                propValue: undefined,
                 startLoc: node.loc.start,
                 endLoc: node.loc.end,
                 prettyCode: formatPrettyCode(


### PR DESCRIPTION
The initial version of implementation for https://github.com/wavebeem/jsx-info/issues/16

- [x]  Do we need to differentiate other types rather than string/symbol? It's possible to return at least boolean and number types.
- [x]  Is the fixture `fixtures/prop-usage/multiplePropTypes.js` looks good or it makes sense to keep everything in `main.js`?